### PR TITLE
Remove Python 3.6; add 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,26 @@ jobs:
       dist: xenial
       sudo: true
       script: tox -e py37
-    - python: 3.7
+    - python: 3.8
       name: "Coverage"
       dist: xenial
       sudo: true
       script: tox -e coverage
-    - python: 3.7
+    - python: 3.8
       name: "Bandit"
       dist: xenial
       sudo: true
       script: tox -e bandit
-    - python: 3.6
-      name: "Python 3.6"
+    - python: 3.8
+      name: "Python 3.8"
       dist: xenial
       sudo: true
-      script: tox -e py36
+      script: tox -e py38
+    - python: 3.9
+      name: "Python 3.9"
+      dist: xenial
+      sudo: true
+      script: tox -e py39
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ jobs:
       dist: xenial
       sudo: true
       script: tox -e py38
-    - python: 3.9
-      name: "Python 3.9"
-      dist: xenial
-      sudo: true
-      script: tox -e py39
 branches:
   only:
   - master

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ omit = src/detection_utils/_version.py
 
 # all of the following is the configuration for tox
 [tox:tox]
-envlist = py37, py38, py39, coverage, bandit
+envlist = py37, py38, coverage, bandit
 
 [testenv]
 passenv = HYPOTHESIS_PROFILE TRAVIS TRAVIS_*

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ omit = src/detection_utils/_version.py
 
 # all of the following is the configuration for tox
 [tox:tox]
-envlist = py36, py37, coverage, bandit
+envlist = py37, py38, py39, coverage, bandit
 
 [testenv]
 passenv = HYPOTHESIS_PROFILE TRAVIS TRAVIS_*
@@ -26,7 +26,7 @@ commands = pytest tests
 
 [testenv:coverage]
 usedevelop = true
-basepython = python3.7
+basepython = python3.8
 deps = {[testenv]deps}
        coverage
        pytest-cov
@@ -34,6 +34,6 @@ setenv = NUMBA_DISABLE_JIT=1
 commands = pytest --cov-report term-missing --cov-config=setup.cfg --cov=detection_utils tests
 
 [testenv:bandit]
-basepython = python3.7
+basepython = python3.8
 deps = bandit
 commands = bandit -r {envsitepackagesdir}/detection_utils/

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ CLASSIFIERS = [
     "Intended Audience :: Education",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
 ]
 INSTALL_REQUIRES = ['numpy >= 1.13', 'numba >= 0.38']

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
 ]
 INSTALL_REQUIRES = ['numpy >= 1.13', 'numba >= 0.38']

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
           url=URL,
           version=versioneer.get_version(),
           cmdclass=versioneer.get_cmdclass(),
-          python_requires='>=3.6',
+          python_requires='>=3.7',
           packages=find_packages(where='src', exclude=['tests*']),
           package_dir={'': 'src'},
           )


### PR DESCRIPTION
The Python 3.6 environment seems to be having issues. This follows [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) and drops support for Python 3.6 and adds 3.8